### PR TITLE
Update build with new Python and dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ RUN cd $DIRPATH && \
     pip install cython && \
     # Now install other Python packages via pip
     pip install \
-        qt numpy scipy sympy==1.3 cython nose lxml matplotlib networkx \
+        numpy scipy sympy==1.3 cython nose lxml matplotlib networkx \
         ipython pandas jsonschema coverage python-coveralls boto3
         doctest-ignore-unicode sqlalchemy psycopg2-binary reportlab
         docstring-parser pyjnius==1.1.4 python-libsbml bottle gunicorn

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,15 +26,6 @@ ENV DIRPATH /sw
 ENV BNGPATH=$DIRPATH/BioNetGen-2.4.0
 ENV PATH="$DIRPATH/miniconda/bin:$PATH"
 ENV KAPPAPATH=$DIRPATH/KaSim
-# Default character encoding for Java in Docker is not UTF-8, which
-# leads to problems with REACH; so we set option
-# See https://github.com/docker-library/openjdk/issues/32
-ENV JAVA_TOOL_OPTIONS -Dfile.encoding=UTF8
-# These are used by INDRA when running REACH
-ENV REACHDIR=$DIRPATH/reach
-ENV REACHPATH=$REACHDIR/reach-61059a-biores-e9ee36.jar
-ENV REACH_VERSION=1.3.3-61059a-biores-e9ee36
-ENV SPARSERPATH=$DIRPATH/sparser
 
 WORKDIR $DIRPATH
 
@@ -67,10 +58,22 @@ RUN cd $DIRPATH && \
     tar xzf bionetgen.tar.gz
 
 # Add and set up reading systems
+# ------------------------------
+# SPARSER
+ENV SPARSERPATH=$DIRPATH/sparser
 ADD r3.core $SPARSERPATH/r3.core
 ADD save-semantics.sh $SPARSERPATH/save-semantics.sh
 ADD version.txt $SPARSERPATH/version.txt
-ADD reach-1.6.1-SNAPSHOT-FAT.jar $REACHDIR/reach-1.6.1-SNAPSHOT-FAT.jar
-
 RUN chmod +x $SPARSERPATH/save-semantics.sh && \
     chmod +x $SPARSERPATH/r3.core
+
+# REACH
+# Default character encoding for Java in Docker is not UTF-8, which
+# leads to problems with REACH; so we set option
+# See https://github.com/docker-library/openjdk/issues/32
+ENV JAVA_TOOL_OPTIONS -Dfile.encoding=UTF8
+ENV REACHDIR=$DIRPATH/reach
+ENV REACHPATH=$REACHDIR/reach-1.6.1-SNAPSHOT-FAT.jar
+ENV REACH_VERSION=1.6.1
+ADD reach-1.6.1-SNAPSHOT-FAT.jar $REACHPATH
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,8 +36,8 @@ RUN cd $DIRPATH && \
         ipython pandas jsonschema coverage python-coveralls boto3 \
         doctest-ignore-unicode sqlalchemy psycopg2-binary reportlab \
         docstring-parser pyjnius==1.1.4 python-libsbml bottle gunicorn \
-        openpyxl flask<2.0 flask_restx<0.4 flask_cors obonet \
-        jinja2 ndex2==2.0.1 requests stemming nltk<3.6 unidecode future pykqml \
+        openpyxl flask==1.1.4 flask_restx==0.3.0 flask_cors obonet \
+        jinja2 ndex2==2.0.1 requests stemming nltk==3.5 unidecode future pykqml \
         paths-graph protmapper gilda adeft kappy==4.0.94 pybel==0.15.4 pysb==1.9.1 \
         objectpath rdflib==4.2.2 pygraphviz pybiopax tqdm scikit-learn && \
     pip uninstall -y enum34 && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN apt-get update && \
     apt-get install -y openjdk-8-jdk && \
     # jnius-indra requires cython which requires gcc
     apt-get install -y git wget zip unzip bzip2 gcc graphviz graphviz-dev \
-        pkg-config python3 python3-pip && \
+        pkg-config python3 python3-pip
 
 # Set default character encoding
 # See http://stackoverflow.com/questions/27931668/encoding-problems-when-running-an-app-in-docker-python-java-ruby-with-u/27931669

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,7 @@ RUN cd $DIRPATH && \
         docstring-parser pyjnius==1.1.4 python-libsbml bottle gunicorn \
         openpyxl flask==1.1.4 flask_restx==0.3.0 flask_cors obonet \
         jinja2 ndex2==2.0.1 requests stemming nltk==3.5 unidecode future pykqml \
-        paths-graph protmapper gilda adeft kappy==4.0.94 pybel==0.15.4 pysb==1.9.1 \
+        paths-graph protmapper gilda adeft kappy==4.1.2 pybel==0.15.4 pysb==1.9.1 \
         objectpath rdflib==4.2.2 pygraphviz pybiopax tqdm scikit-learn && \
     pip uninstall -y enum34 && \
     # Download protmapper resources

--- a/Dockerfile
+++ b/Dockerfile
@@ -70,7 +70,7 @@ RUN cd $DIRPATH && \
 ADD r3.core $SPARSERPATH/r3.core
 ADD save-semantics.sh $SPARSERPATH/save-semantics.sh
 ADD version.txt $SPARSERPATH/version.txt
+ADD reach-1.6.1-SNAPSHOT-FAT.jar $REACHDIR/reach-1.6.1-SNAPSHOT-FAT.jar
 
 RUN chmod +x $SPARSERPATH/save-semantics.sh && \
-    chmod +x $SPARSERPATH/r3.core && \
-    wget -nv http://sorger.med.harvard.edu/data/bachman/reach-61059a-biores-e9ee36.jar -P $REACHDIR
+    chmod +x $SPARSERPATH/r3.core

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,16 +20,15 @@ ENV LC_ALL en_US.UTF-8  #
 # Set environment variables
 ENV DIRPATH /sw
 ENV BNGPATH=$DIRPATH/BioNetGen-2.4.0
-ENV PATH="$DIRPATH/miniconda/bin:$PATH"
 ENV KAPPAPATH=$DIRPATH/KaSim
 ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64
 
 WORKDIR $DIRPATH
 
-# Set up Miniconda and Python dependencies
+# Set up Python dependencies
 RUN cd $DIRPATH && \
-    # Install packages that are available via conda directly
     pip install --upgrade pip && \
+    # Install cython first for pyjnius
     pip install cython && \
     # Now install other Python packages via pip
     pip install \

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,9 +33,9 @@ RUN cd $DIRPATH && \
     # Now install other Python packages via pip
     pip install \
         numpy scipy sympy==1.3 cython nose lxml matplotlib networkx \
-        ipython pandas jsonschema coverage python-coveralls boto3
-        doctest-ignore-unicode sqlalchemy psycopg2-binary reportlab
-        docstring-parser pyjnius==1.1.4 python-libsbml bottle gunicorn
+        ipython pandas jsonschema coverage python-coveralls boto3 \
+        doctest-ignore-unicode sqlalchemy psycopg2-binary reportlab \
+        docstring-parser pyjnius==1.1.4 python-libsbml bottle gunicorn \
         openpyxl flask<2.0 flask_restx<0.4 flask_cors obonet \
         jinja2 ndex2==2.0.1 requests stemming nltk<3.6 unidecode future pykqml \
         paths-graph protmapper gilda adeft kappy==4.0.94 pybel==0.15.4 pysb==1.9.1 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -65,9 +65,9 @@ RUN chmod +x $SPARSERPATH/save-semantics.sh && \
 # See https://github.com/docker-library/openjdk/issues/32
 ENV JAVA_TOOL_OPTIONS -Dfile.encoding=UTF8
 ENV REACHDIR=$DIRPATH/reach
-ENV REACHPATH=$REACHDIR/reach-1.6.3-9ed6fe.jar
-ENV REACH_VERSION=1.6.3-9ed6fe
-ADD reach-1.6.3-9ed6fe.jar $REACHPATH
+ENV REACHPATH=$REACHDIR/reach-1.6.3-e48717.jar
+ENV REACH_VERSION=1.6.3-e48717.jar
+ADD reach-1.6.3-e48717.jar $REACHPATH
 
 # MTI
 ADD mti_jars.zip $DIRPATH

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,6 @@ ENV LC_ALL en_US.UTF-8  #
 # Set environment variables
 ENV DIRPATH /sw
 ENV BNGPATH=$DIRPATH/BioNetGen-2.4.0
-ENV KAPPAPATH=$DIRPATH/KaSim
 ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64
 
 WORKDIR $DIRPATH

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,8 @@ RUN apt-get update && \
     apt-get install -y openjdk-8-jdk && \
     # jnius-indra requires cython which requires gcc
     apt-get install -y git wget zip unzip bzip2 gcc graphviz graphviz-dev \
-        pkg-config python3 python3-pip
+        pkg-config python3 python3-pip && \
+    ln -s /usr/bin/python3 /usr/bin/python
 
 # Set default character encoding
 # See http://stackoverflow.com/questions/27931668/encoding-problems-when-running-an-app-in-docker-python-java-ruby-with-u/27931669

--- a/README.md
+++ b/README.md
@@ -1,13 +1,12 @@
 # indra_deps_docker
 
-Docker image to build INDRA dependencies including REACH, PySB and Kappa.
+Docker image to build INDRA dependencies including Reach, PySB and Kappa.
 
 ## Procedure for updating Docker image on AWS
 
-* Commit changes to Dockerfile in johnbachman/indra_deps_docker.
+* Commit changes to Dockerfile in indralab/indra_deps_docker.
 * Log into AWS.
 * Go to CodeBuild. In list of Build projects, select indra_deps_docker
-  and click "Start build". On next page, accept setting and click
-  "Start build."
+  and click "Start build".
 * If build is successful, proceed to updating build of
-  johnbachman/indra_docker.
+  indralab/indra_docker.

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -10,7 +10,7 @@ phases:
       - aws s3 cp s3://bigmech/sparser_core/r3.core .
       - aws s3 cp s3://bigmech/sparser_core/version.txt .
       - echo Getting Reach
-      - aws s3 cp s3://bigmech/reach-1.6.3-9ed6fe.jar .
+      - aws s3 cp s3://bigmech/reach-1.6.3-e48717.jar .
       - aws s3 cp s3://bigmech/travis/mti_jars_v2.zip ./mti_jars.zip
   build:
     commands:

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -9,6 +9,7 @@ phases:
       - aws s3 cp s3://bigmech/sparser_core/save-semantics.sh .
       - aws s3 cp s3://bigmech/sparser_core/r3.core .
       - aws s3 cp s3://bigmech/sparser_core/version.txt .
+      - aws s3 cp s3://bigmech/reach-1.6.1-SNAPSHOT-FAT.jar .
   build:
     commands:
       - echo Build started on `date`

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -3,13 +3,14 @@ version: 0.1
 phases:
   pre_build:
     commands:
-      - echo Getting sparser core
       - echo Logging in to Amazon ECR...
       - $(aws ecr get-login --region $AWS_DEFAULT_REGION)
+      - echo Getting Sparser
       - aws s3 cp s3://bigmech/sparser_core/save-semantics.sh .
       - aws s3 cp s3://bigmech/sparser_core/r3.core .
       - aws s3 cp s3://bigmech/sparser_core/version.txt .
-      - aws s3 cp s3://bigmech/reach-1.6.1-SNAPSHOT-FAT.jar .
+      - echo Getting Reach
+      - aws s3 cp s3://bigmech/reach-1.6.3-9ed6fe.jar .
   build:
     commands:
       - echo Build started on `date`

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -11,6 +11,7 @@ phases:
       - aws s3 cp s3://bigmech/sparser_core/version.txt .
       - echo Getting Reach
       - aws s3 cp s3://bigmech/reach-1.6.3-9ed6fe.jar .
+      - aws s3 cp s3://bigmech/travis/mti_jars_v2.zip ./mti_jars.zip
   build:
     commands:
       - docker login -u "${DOCKERHUB_USER}" -p "${DOCKERHUB_PWD}"

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -13,6 +13,7 @@ phases:
       - aws s3 cp s3://bigmech/reach-1.6.3-9ed6fe.jar .
   build:
     commands:
+      - docker login -u "${DOCKERHUB_USER}" -p "${DOCKERHUB_PWD}"
       - echo Build started on `date`
       - echo Building the Docker image...
       - docker build -t $IMAGE_REPO_NAME:$IMAGE_TAG .


### PR DESCRIPTION
This PR makes several updates to the build:
- Use Ubuntu 20.04 as a base image
- Remove the conda installation (which was just a workaround to get more recent Python versions on old Linux distros) and instead just use the default python3 that comes with Ubuntu 20.04.
- Update pip install list with current INDRA dependencies, backporting things that were added since the last update of this build to `indra_docker`
- Update Reach to a new version
- Backport MTI installation from `indra_docker` build